### PR TITLE
Should be possible to instruct module not to exit process

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ The following options are available:
 * __logger:__ Function that accepts a string to output a log message (default console.log).
 * __suicideTimeout:__ The timeout to forcefully exit the process with a return code of 1 (default 3 minutes).
 * __socketio:__ An instance of socket.io, that will close all open socket.io connections (default none)
+* __exitProcess:__ Instructs this module to call process.exit it is done (default true).
+* __callback:__ Function that will be called with the "exit" status code once closing express is done (for good or worse). Should be use in conjunction with exitProcess=false, where it is the responsilbity of the caller to handle process shutdown.
 
 ## Details
 

--- a/lib/graceful-exit.js
+++ b/lib/graceful-exit.js
@@ -25,11 +25,29 @@ exports.gracefulExitHandler = function(app, server, _options) {
       log               : false
     , logger            : console.log
     , suicideTimeout    : 2*60*1000 + 10*1000 // 2m10s (nodejs default is 2m)
+    , exitProcess       : true
   })
 
   function logger(str) {
     if (options.log)
       options.logger(str)
+  }
+
+  function exit(code) {
+    if (options.exitProcess){
+      process.exit(code)
+    } else if (options.callback) {
+      if (_.isFunction(options.callback)) {
+        options.callback(code)
+      } else {
+        logger("Registered callback is not a function")
+      }
+    }
+  }
+
+  if (options.callback && options.exitProcess) {
+    logger("Registering a callback and exiting is not advised. " +
+           "Callback should be registered when process shutdwon is handled by the caller");
   }
 
   logger('Closing down the server')
@@ -41,7 +59,7 @@ exports.gracefulExitHandler = function(app, server, _options) {
   server.close(function() {
     // Everything was closed successfully, mission accomplished!
     logger('All connections done, stopping process')
-    process.exit(0)
+    exit(0)
   })
 
   // Disconnect all the socket.io clients
@@ -57,6 +75,6 @@ exports.gracefulExitHandler = function(app, server, _options) {
   // be graceful, but failed.
   setTimeout(function() {
     logger('Exiting process with some open connections left')
-    process.exit(1)
+    exit(1);
   }, options.suicideTimeout)
 }


### PR DESCRIPTION
This is useful when additional graceful shutdowns are required after express is closed (e.g. flushing an closing loggers, db connections, redis connections etc.)