### PR TITLE
Support force shutdown of express

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The following options are available:
 * __logger:__ Function that accepts a string to output a log message (default console.log).
 * __suicideTimeout:__ The timeout to forcefully exit the process with a return code of 1 (default 3 minutes).
 * __socketio:__ An instance of socket.io, that will close all open socket.io connections (default none)
+* __force:__ Instructs the module to forcibly close sockets once the suicide timeout elapses. Requires that gracefulExit.init(server) be called when initializing the HTTP server (default: false)
 
 ## Details
 

--- a/lib/graceful-exit.js
+++ b/lib/graceful-exit.js
@@ -1,21 +1,19 @@
 
 var _ = require('underscore')
+var sockets = []
 
-exports.middleware = function(app) {
-  // This flag is used to tell the middleware we create that the server wants
-  // to stop, so we do not allow anymore connections. This is done for all new
-  // connections for us by Node, but we need to handle the connections that are
-  // using the Keep-Alive header to stay on.
-  app.set('graceful_exit', false)
+/**
+ * Keep track of open connections so we can forcibly close sockets when the suicide timeout elapses
+ * @param server HTTP server
+ */
+exports.init = function (server) {
+  server.on('connection', function (socket) {
+    sockets.push(socket)
 
-  return function(req, res, next) {
-    // Sorry Keep-Alive connections, but we need to part ways
-    if (app.settings.graceful_exit === true) {
-      req.connection.setTimeout(1)
-    }
-
-    next()
-  }
+    socket.on('close', function () {
+      sockets.splice(sockets.indexOf(socket), 1)
+    })
+  })
 }
 
 exports.gracefulExitHandler = function(app, server, _options) {
@@ -25,6 +23,7 @@ exports.gracefulExitHandler = function(app, server, _options) {
       log               : false
     , logger            : console.log
     , suicideTimeout    : 2*60*1000 + 10*1000 // 2m10s (nodejs default is 2m)
+    , force             : false
   })
 
   function logger(str) {
@@ -56,7 +55,32 @@ exports.gracefulExitHandler = function(app, server, _options) {
   // connections lingering around for some reason, just die... we tried to
   // be graceful, but failed.
   setTimeout(function() {
-    logger('Exiting process with some open connections left')
+    if (options.force) {
+      logger('Destorying ' + sockets.length + ' open sockets')
+      sockets.forEach(function (socket) {
+        socket.destroy()
+      })
+    } else {
+      logger('Exiting process with some open connections left')
+    }
     process.exit(1)
+
   }, options.suicideTimeout)
+}
+
+exports.middleware = function(app) {
+  // This flag is used to tell the middleware we create that the server wants
+  // to stop, so we do not allow anymore connections. This is done for all new
+  // connections for us by Node, but we need to handle the connections that are
+  // using the Keep-Alive header to stay on.
+  app.set('graceful_exit', false)
+
+  return function(req, res, next) {
+    // Sorry Keep-Alive connections, but we need to part ways
+    if (app.settings.graceful_exit === true) {
+      req.connection.setTimeout(1)
+    }
+
+    next()
+  }
 }


### PR DESCRIPTION
Calling close() on the HTTP server is not enough to ensure destruction of all sockets. As most connections are "kept-alive", calling close will just hang. It should be possible to configure the module to destroy all sockets, including persistent connection sockets.